### PR TITLE
Digits fix rounding add readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,11 @@ License: "GNU GPLv2"
 My changes are copyright to flowerbug@anthive.com, but nothing I'm doing is very complicated.
 
 
-# News For v3.0.0, Fix for Rounding Error, Use of -z Option
+# News For v3.0.0, Fix for Rounding Error, Use of -z Option, add readline
 
 Please use at least version (v3.0.0) and report any issues that are not noted below.
 
 The previous versions used the default ROUND_HALF_EVEN method in one place which could cause unbalanced beancount transactions.  My broker uses ROUND_HALF_UP and so to make that possible along with the existing default I've added the -z option which changes the rounding method to ROUND_HALF_UP.
-
-Along with these changes I also may have made the output of the default version slightly different and so until tested for a while I'd consider this a potential breaking change.
 
 
 # Introduction and Rationale
@@ -194,7 +192,7 @@ I have not had to add any new commodities/symbols to the commodities.bc file, bu
 
 Currently no error checking is done on the destination location or file or permissions.
 
-Rounding of transaction amounts is not what I would do, but account statements might.  My previous versions did generate unbalanced transactions in certain instances.  Versions 3.0.0 and above I hope will fix this issue along with adding the -z option to use a different rounding method.
+Rounding of transaction amounts is not what I would do, but account statements might.  My previous versions did generate unbalanced transactions in certain instances.  Versions 3.0.0 and above fix this issue along with adding the -z option to use a different rounding method.
 
 No errors or issues I'm aware of other than those I've noted here or up above.
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ License: "GNU GPLv2"
 My changes are copyright to flowerbug@anthive.com, but nothing I'm doing is very complicated.
 
 
-# Latest News For v2.3.6, Added Backdate and Tag Options
+# News For v3.0.0, Fix for Rounding Error, Use of -z Option
 
-Please use the current version (v2.3.6) and report any issues that are not noted below.
+Please use at least version (v3.0.0) and report any issues that are not noted below.
 
-The -b "backdate" and -t tag options are useful for when you've missed a day or want to use the actual Buy execution time or an approximate time when the Buy happened.  More details are included below.
+The previous versions used the default ROUND_HALF_EVEN method in one place which could cause unbalanced beancount transactions.  My broker uses ROUND_HALF_UP and so to make that possible along with the existing default I've added the -z option which changes the rounding method to ROUND_HALF_UP.
+
+Along with these changes I also may have made the output of the default version slightly different and so until tested for a while I'd consider this a potential breaking change.
 
 
 # Introduction and Rationale
@@ -42,7 +44,7 @@ When Done type in D.
 <pre>
 $ python bcgt.py --help ledger.bc
 
-usage: bcgt.py [-h] [-dest DESTINATION] [-C CURRENCY] [-s] [-f]
+usage: bcgt.py [-h] [-dest DESTINATION] [-C CURRENCY] [-s] [-f] [-z]
                [-c OUTPUT_COMMODITIES] [-a OUTPUT_ACCOUNTS] [-p OUTPUT_PRICES]
                [-r OUTPUT_RATES] [-m OUTPUT_POSTINGS] [-o OUTPUT]
                filename
@@ -87,6 +89,9 @@ options:
   -f, --switch-lot-pref
                         Override the default lot sale selection order to
                         FIFO(default is LIFO)
+  -z, --switch-round-pref
+                        Override the default rounding preference to
+                        ROUND_HALF_UP(default is ROUND_HALF_EVEN)
   -c OUTPUT_COMMODITIES, --output_commodities OUTPUT_COMMODITIES
                         CSV filename to write out the commodities table to.
   -a OUTPUT_ACCOUNTS, --output_accounts OUTPUT_ACCOUNTS
@@ -188,6 +193,8 @@ If you buy a stock today you can't split it until tomorrow as beancount doesn't 
 I have not had to add any new commodities/symbols to the commodities.bc file, but at some point I hope to make that work automatically.  I usually edit prices.bc to add new symbols, but I also hope to get that to happen automatically.
 
 Currently no error checking is done on the destination location or file or permissions.
+
+Rounding of transaction amounts is not what I would do, but account statements might.  My previous versions did generate unbalanced transactions in certain instances.  Versions 3.0.0 and above I hope will fix this issue along with adding the -z option to use a different rounding method.
 
 No errors or issues I'm aware of other than those I've noted here or up above.
 

--- a/bcgt.py
+++ b/bcgt.py
@@ -29,6 +29,7 @@ import csv
 import datetime
 import dateparser
 import time
+import readline
 import os
 import re
 
@@ -469,17 +470,17 @@ def sell_shares(list, pos, sym, shares_to_sell, price, backdate, currency, sregf
         basis_price = list[sell_pos][4]
         #print ("Basis Price : ", basis_price)
         basis_val = basis_price * sell_these
-        print ("\n Raw Basis Val  : ", basis_val)
-        print (" Basis Val  : ", newmoneyfmt(basis_val))
+        #print ("\n Raw Basis Val  : ", basis_val)
+        #print (" Basis Val  : ", newmoneyfmt(basis_val))
         #print ("\n Sale Price : ", price")
         raw_sale_value = sell_these * price
         sale_value = Decimal(raw_sale_value).quantize(Decimal('.01'), rounding=rounding_preference)
-        print ("\n Raw Sale Value : ", raw_sale_value)
-        print (" Sale Value : ", sale_value)
+        #print ("\n Raw Sale Value : ", raw_sale_value)
+        #print (" Sale Value : ", sale_value)
         raw_sale_pnl = (raw_sale_value - basis_val - this_regfee) * Decimal(-1)
         sale_pnl = Decimal((raw_sale_value - basis_val - this_regfee) * Decimal(-1)).quantize(Decimal('.01'), rounding=rounding_preference)
-        print ("\n Raw Sale_PnL : ", raw_sale_pnl)
-        print (" Sale_PnL : ", sale_pnl, "\n")
+        #print ("\n Raw Sale_PnL : ", raw_sale_pnl)
+        #print (" Sale_PnL : ", sale_pnl, "\n")
         
         if (backdate == None):
             todayorbackdate_str = '{:%Y-%m-%d}'.format(stoday)

--- a/bcgt.py
+++ b/bcgt.py
@@ -22,7 +22,7 @@ __copyright__ = "modified by flowerbug@anthive.com"
 __license__ = "GNU GPLv2"
 
 from typing import NamedTuple, Tuple, List, Set, Any, Dict
-from decimal import Decimal, getcontext, ROUND_HALF_EVEN
+from decimal import Decimal, getcontext, ROUND_HALF_EVEN, ROUND_HALF_UP
 from operator import itemgetter
 import argparse
 import csv
@@ -261,6 +261,9 @@ def do_args():
     parser.add_argument('-f', '--switch-lot-pref', action='store_true',
                         help=("Override the default lot sale selection order to FIFO"
                               "(default is LIFO)"))
+    parser.add_argument('-z', '--switch-round-pref', action='store_true',
+                        help=("Override the default rounding preference to ROUND_HALF_UP"
+                              "(default is ROUND_HALF_EVEN)"))
 
     for shortname, longname in [('-c', 'commodities'),
                                 ('-a', 'accounts'),
@@ -388,7 +391,7 @@ def buy_shares(sym, shares_to_buy, price, backdate, tag, currency,
 
 # Sell shares
 def sell_shares(list, pos, sym, shares_to_sell, price, backdate, currency, sregfee,
-    order, stoday, asset_str, expenses_str, equity_fees_str, income_str, mm_str, tmpfile):
+    order, stoday, rounding_preference, asset_str, expenses_str, equity_fees_str, income_str, mm_str, tmpfile):
     """Sell shares where the order of lots is determined by how
     the list is sorted (LIFO is the default, FIFO is the other
     option available).  The only error is if the shares do not
@@ -456,7 +459,7 @@ def sell_shares(list, pos, sym, shares_to_sell, price, backdate, currency, sregf
         lot_date = list[sell_pos][6]
         #print ("Lot_Shares  :", lot_shares)
         #print ("These_Shares  :", sell_these)
-        this_regfee = Decimal(regfee_per_share * sell_these).quantize(Decimal('.01'), rounding=ROUND_HALF_EVEN)
+        this_regfee = Decimal(regfee_per_share * sell_these).quantize(Decimal('.01'), rounding=rounding_preference)
         #print ("This Regfee : ", this_regfee)
         if (this_regfee > whats_left):
             #print (" Remaining fee ignored : ", this_regfee - whats_left)
@@ -466,12 +469,18 @@ def sell_shares(list, pos, sym, shares_to_sell, price, backdate, currency, sregf
         basis_price = list[sell_pos][4]
         #print ("Basis Price : ", basis_price)
         basis_val = basis_price * sell_these
-        #print (" Basis Val  : ", newmoneyfmt(basis_val))
-        #print (" Sale Price : ", price, "\n")
-
-        sale_value = sell_these * price
-        #print (" Sale Value : ", sale_value, "\n")
-        sale_pnl = (sale_value - basis_val - this_regfee) * Decimal(-1)
+        print ("\n Raw Basis Val  : ", basis_val)
+        print (" Basis Val  : ", newmoneyfmt(basis_val))
+        #print ("\n Sale Price : ", price")
+        raw_sale_value = sell_these * price
+        sale_value = Decimal(raw_sale_value).quantize(Decimal('.01'), rounding=rounding_preference)
+        print ("\n Raw Sale Value : ", raw_sale_value)
+        print (" Sale Value : ", sale_value)
+        raw_sale_pnl = (raw_sale_value - basis_val - this_regfee) * Decimal(-1)
+        sale_pnl = Decimal((raw_sale_value - basis_val - this_regfee) * Decimal(-1)).quantize(Decimal('.01'), rounding=rounding_preference)
+        print ("\n Raw Sale_PnL : ", raw_sale_pnl)
+        print (" Sale_PnL : ", sale_pnl, "\n")
+        
         if (backdate == None):
             todayorbackdate_str = '{:%Y-%m-%d}'.format(stoday)
         else:
@@ -487,13 +496,13 @@ def sell_shares(list, pos, sym, shares_to_sell, price, backdate, currency, sregf
         #print (str1)
         str2 = '  '+asset_str+sym+'    '+str(sell_these * Decimal(-1))+' '+sym+' {'+str(basis_price)+' '+currency+', '+lot_date_str+', "'+lot+'"} @ '+str(price)+' '+currency+'\n'
         #print (str2)
-        str3 = '  '+expenses_str+":"+sym+'    '+moneyfmt(this_regfee)+' '+currency+'\n'
+        str3 = '  '+expenses_str+":"+sym+'    '+str(this_regfee)+' '+currency+'\n'
         #print (str3)
-        str4 = '  '+equity_fees_str+'    '+moneyfmt(Decimal(-1) * this_regfee)+' '+currency+'\n'
+        str4 = '  '+equity_fees_str+'    '+str(Decimal(-1) * this_regfee)+' '+currency+'\n'
         #print (str4)
-        str5 = '  '+income_str+sym+'    '+moneyfmt(sale_pnl)+' '+currency+'\n'
+        str5 = '  '+income_str+sym+'    '+str(sale_pnl)+' '+currency+'\n'
         #print (str5)
-        str6 = '  '+mm_str+'    '+moneyfmt(sale_value - this_regfee)+' '+currency+"\n\n"
+        str6 = '  '+mm_str+'    '+str(sale_value - this_regfee)+' '+currency+"\n\n"
         #print (str6)
         print (str0, str1, str2, str3, str4, str5, str6, file=tmpfile)
 
@@ -636,6 +645,14 @@ def main():
     else:
         print ("Lots are Sold in FIFO order.\n")
         lotorder = 'FIFO'
+
+    # Rounding method preference selection -z will change ROUND_HALF_EVEN to ROUND_HALF_UP
+    if (args.switch_round_pref != True):
+        print ("Rounding preference is ROUND_HALF_EVEN.\n")
+        rounding_preference = ROUND_HALF_EVEN
+    else:
+        print ("Rounding preference is ROUND_HALF_UP.\n")
+        rounding_preference = ROUND_HALF_UP
 
     # destination of transactions, must always be set one way or another
     if args.destination is not None:
@@ -950,7 +967,7 @@ def main():
                 amt_val = newmoneyfmt(price * num)
                 #print ("Amt : ", amt_val)
 
-                tot_trans = sell_shares (slist, z, sym, num, price, backdate, main_currency, regfee, lotorder, today, asset_str, expenses_str, equity_fees_str, income_str, mm_str, tmp_bcgtfile)
+                tot_trans = sell_shares (slist, z, sym, num, price, backdate, main_currency, regfee, lotorder, today, rounding_preference, asset_str, expenses_str, equity_fees_str, income_str, mm_str, tmp_bcgtfile)
 
             # Split
             elif command == 'X':


### PR DESCRIPTION
Added -z option for those who want to use the alternative rounding method ROUND_HALF_UP (the default remains ROUND_HALF_EVEN).

Also added readline to make editing during input more useful.